### PR TITLE
Remove stray && when using bootsnap

### DIFF
--- a/lib/generators/templates/Dockerfile.erb
+++ b/lib/generators/templates/Dockerfile.erb
@@ -63,7 +63,7 @@ RUN --mount=type=cache,id=bld-gem-cache,sharing=locked,target=/srv/vendor \
     bundle config set app_config .bundle && \
     bundle config set path /srv/vendor && \
     bundle _${BUNDLER_VERSION}_ install && \
-<% if depend_on_bootsnap? -%> && \
+<% if depend_on_bootsnap? -%>
     bundle exec bootsnap precompile --gemfile && \
 <% end -%>
     bundle clean && \


### PR DESCRIPTION
Remove a ` && \` that would generate a syntax error.

**Before**:
```
RUN --mount=type=cache,id=bld-gem-cache,sharing=locked,target=/srv/vendor \
    bundle config set app_config .bundle && \
    bundle config set path /srv/vendor && \
    bundle _${BUNDLER_VERSION}_ install && \
 && \
    bundle exec bootsnap precompile --gemfile && \
    bundle clean && \
    mkdir -p vendor && \
    bundle config set path vendor && \
    cp -ar /srv/vendor .
```

**After**:
```
RUN --mount=type=cache,id=bld-gem-cache,sharing=locked,target=/srv/vendor \
    bundle config set app_config .bundle && \
    bundle config set path /srv/vendor && \
    bundle _${BUNDLER_VERSION}_ install && \
    bundle exec bootsnap precompile --gemfile && \
    bundle clean && \
    mkdir -p vendor && \
    bundle config set path vendor && \
    cp -ar /srv/vendor .
```