### PR TITLE
Fix homepage link in gemspec

### DIFF
--- a/dockerfile-rails.gemspec
+++ b/dockerfile-rails.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |spec|
     "Sam Ruby",
   ]
   spec.email       = "rubys@intertwingly.net"
-  spec.homepage    = "https://github.com/rubys/docker-rails"
+  spec.homepage    = "https://github.com/rubys/dockerfile-rails"
   spec.summary     = "Dockerfile generator for Rails"
   spec.license     = "MIT"
 


### PR DESCRIPTION
I noticed on https://rubygems.org that the homepage link for this gem was broken. Looks like just a small typo. 