### PR TITLE
Read from package.json engines.node

### DIFF
--- a/lib/generators/dockerfile_generator.rb
+++ b/lib/generators/dockerfile_generator.rb
@@ -104,7 +104,9 @@ class DockerfileGenerator < Rails::Generators::Base
     template 'Dockerfile.erb', 'Dockerfile'
     template 'dockerignore.erb', '.dockerignore'
 
-    template 'node-version.erb', '.node-version' if using_node?
+    if using_node? and node_version =~ /\A\d+\.\d+\.\d+\z/
+      template 'node-version.erb', '.node-version' 
+    end
 
     template 'docker-entrypoint.erb', 'bin/docker-entrypoint'
     chmod "bin/docker-entrypoint", 0755 & ~File.umask, verbose: false

--- a/lib/generators/dockerfile_generator.rb
+++ b/lib/generators/dockerfile_generator.rb
@@ -380,12 +380,16 @@ private
   end
 
   def node_version
-    if File.exist? '.node_version'
-      IO.read('.node_version')[/\d+\.\d+\.\d+/]
-    elsif File.exist? 'package.json'
-      JSON.parse(IO.read('package.json')).dig("engines", "node")
+    if File.exist? '.node-version'
+      IO.read('.node-version')[/\d+\.\d+\.\d+/]
     else
-      `node --version`[/\d+\.\d+\.\d+/]
+      version = nil
+
+      if File.exist? 'package.json'
+        version = JSON.parse(IO.read('package.json')).dig("engines", "node")
+      end
+
+      version || `node --version`[/\d+\.\d+\.\d+/]
     end
   rescue
     "lts" 

--- a/lib/generators/dockerfile_generator.rb
+++ b/lib/generators/dockerfile_generator.rb
@@ -389,6 +389,7 @@ private
 
       if File.exist? 'package.json'
         version = JSON.parse(IO.read('package.json')).dig("engines", "node")
+        version = nil unless version =~ /\A(\d+\.)+(\d+|x)\z/
       end
 
       version || `node --version`[/\d+\.\d+\.\d+/]

--- a/lib/generators/dockerfile_generator.rb
+++ b/lib/generators/dockerfile_generator.rb
@@ -382,6 +382,8 @@ private
   def node_version
     if File.exist? '.node_version'
       IO.read('.node_version')[/\d+\.\d+\.\d+/]
+    elsif File.exist? 'package.json'
+      JSON.parse(IO.read('package.json')).dig("engines", "node")
     else
       `node --version`[/\d+\.\d+\.\d+/]
     end


### PR DESCRIPTION
Folks who are deploying Rails apps to Heroku define their version of node in the package file under the `engine.node` key.

Docs at https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version

This PR shows how the node, yarn, and npm version could be resolved from the `package.json` file to be compatible with Heroku Rails app configurations.

If this approach is palatable, it could be expanded to include yarn and npm.

## Problems

The problem with the current approach is it doesn't resolve an exact version of node.js. In my case, I have the following `package.json` file:

```json
{
  "name": "thingybase",
  "engines": {
    "node": "16.x"
  },
  "private": true,
  "dependencies": {},
  "devDependencies": {},
  "packageManager": "yarn@1.22.19"
}
```

The version `16.x` gets set in All The Places™. Node then somehow resolves this to the latest version, which is `16.19.0` at the time of this writing. Ideally the Dockerfile would have `NODE_VERSION=16.19.0` instead of `NODE_VERSION=16.x`. Whatever resolves that would have to be found and included in the generator to make this happen.

Additionally, it's possible to define a range of versions, https://docs.npmjs.com/cli/v9/configuring-npm/package-json#engines. I haven't tested how those would resolve, but it seems like it would be a really bad idea to set `NODE_VERSION` equal to a range of versions since the goal is to generate Dockerfiles where versions don't change.

Finally, the other issue is there's a lot of ways to specify versions for different engines, etc. In the `package.json` file above, you can see there's a `packageManager` key set with the yarn version. Also, if a node engine is defined in `package.json` and via `.node-version` is a warning displayed or do we go by some precedence?