### PR TITLE
Run the correct command for the sidekiq docker container

### DIFF
--- a/lib/generators/templates/docker-compose.yml.erb
+++ b/lib/generators/templates/docker-compose.yml.erb
@@ -73,6 +73,7 @@ services:
 
   sidekiq:
     build: .
+    command: bin/sidekiq
     environment:
       - RAILS_MASTER_KEY=$RAILS_MASTER_KEY
       - REDIS_URL=redis://redis-db:6379

--- a/test/results/sidekiq/docker-compose.yml
+++ b/test/results/sidekiq/docker-compose.yml
@@ -34,6 +34,7 @@ services:
 
   sidekiq:
     build: .
+    command: bin/sidekiq
     environment:
       - RAILS_MASTER_KEY=$RAILS_MASTER_KEY
       - REDIS_URL=redis://redis-db:6379


### PR DESCRIPTION
The Sidekiq container produced was still running the default command `bin/rails server`.

About the newline at the end of the file, do you have a preference? My editor is configured to add one automatically, but I'm happy to remove it if you want.

